### PR TITLE
Updates

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.2
 
 ENV version 1.1.0
 
@@ -10,7 +10,8 @@ RUN apk upgrade --update --available && \
 
 ADD https://github.com/ssllabs/ssllabs-scan/archive/v${version}.tar.gz /tmp/
 
+# https://github.com/golang/go/issues/9344#issuecomment-69944514
 RUN cd /tmp && \
     tar xvzf v${version}.tar.gz && \
     cd ssllabs-scan-${version} && \
-    GOPATH=~ CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w' ssllabs-scan.go
+    GOPATH=~ CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -tags netgo -ldflags '-w' ssllabs-scan.go

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,6 @@
 FROM alpine:3.2
 
+# If you change this, you should change it in circle.yml, too.
 ENV version 1.1.0
 
 RUN apk upgrade --update --available && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -6,12 +6,15 @@ RUN apk upgrade --update --available && \
     apk add \
       ca-certificates \
       go \
+    && adduser -D developer \
     && rm -f /var/cache/apk/*
 
-ADD https://github.com/ssllabs/ssllabs-scan/archive/v${version}.tar.gz /tmp/
+# Run subsequent commands as "developer".
+USER developer
 
 # https://github.com/golang/go/issues/9344#issuecomment-69944514
 RUN cd /tmp && \
+    wget https://github.com/ssllabs/ssllabs-scan/archive/v${version}.tar.gz && \
     tar xvzf v${version}.tar.gz && \
     cd ssllabs-scan-${version} && \
     GOPATH=~ CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -tags netgo -ldflags '-w' ssllabs-scan.go

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,9 @@ runtime: static certfile
 
 test:
 	docker images | grep ssllabs-scan
-	docker run -it jumanjiman/ssllabs-scan -grade -usecache https://github.com
+ifdef CIRCLECI
+	# Circle fails to drop all capabilities.
+	docker run -it --read-only jumanjiman/ssllabs-scan -grade -usecache https://github.com
+else
+	docker run -it --read-only --cap-drop all jumanjiman/ssllabs-scan -grade -usecache https://github.com
+endif

--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ How-to
 
 ### Pull an already-built image
 
-    docker pull jumanjiman/ssllabs-scan
+For user convenience, each published image is tagged with
+`<upstream-version-number>-<git-short-hash>` to correlate
+with both the upstream software release and the git commit
+of this repo. The "latest" tag always points to the most
+recent build.
+
+    docker pull jumanjiman/ssllabs-scan:latest
 
 
 ### Run

--- a/README.md
+++ b/README.md
@@ -59,11 +59,19 @@ recent build.
 
 ### Run
 
-    user@devenv:~/ssllabs-scan$ docker run --read-only --rm -it jumanjiman/ssllabs-scan https://github.com/
-    2015/05/16 18:06:39 [INFO] SSL Labs v1.16.14 (criteria version 2009i)
-    2015/05/16 18:06:39 [NOTICE] Server message: This assessment service is provided free of charge by Qualys SSL Labs, subject to our terms and conditions: https://www.ssllabs.com/about/terms.html
-    2015/05/16 18:06:41 [INFO] Assessment starting: https://github.com/
-    2015/05/16 18:08:21 [INFO] Assessment complete: https://github.com/ (1 host in 95 seconds)
-        192.30.252.131: A+
-    -snip copious json output-
-    2015/05/16 18:08:21 [INFO] All assessments complete; shutting down
+The following example uses `--read-only` and `--cap-drop all` as recommended by the
+[CIS Docker Security Benchmark](https://benchmarks.cisecurity.org/tools2/docker/CIS_Docker_1.6_Benchmark_v1.0.0.pdf).
+
+    user@devenv:~$ docker_opts="--read-only --cap-drop all --rm -it"
+    user@devenv:~$ image="jumanjiman/ssllabs-scan:latest"
+    user@devenv:~$ scan_opts="-grade -usecache"
+    user@devenv:~$ url_to_scan="https://github.com/"
+    user@devenv:~$ docker run ${docker_opts} ${image} ${scan_opts} ${url_to_scan}
+    2015/06/14 23:01:01 [INFO] SSL Labs v1.18.1 (criteria version 2009j)
+    2015/06/14 23:01:01 [NOTICE] Server message: This assessment service is provided free of charge by Qualys SSL Labs, subject to our terms and conditions: https://www.ssllabs.com/about/terms.html
+    2015/06/14 23:01:03 [INFO] Assessment starting: https://github.com
+    2015/06/14 23:01:04 [INFO] Assessment complete: https://github.com (1 host in 96 seconds)
+        192.30.252.129: A+
+    "https://github.com": "A+"
+
+    2015/06/14 23:01:04 [INFO] All assessments complete; shutting down

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,8 @@
 # https://circleci.com/docs/docker
 machine:
+  environment:
+    # If you change this, you should change it in Dockerfile.build, too.
+    VERSION: 1.1.0
   pre:
     - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.0-circleci'
     - sudo chmod 0755 /usr/bin/docker
@@ -25,7 +28,7 @@ deployment:
     commands:
       # squid
       - docker login -e ${mail} -u ${user} -p ${pass}
-      - docker tag jumanjiman/ssllabs-scan jumanjiman/ssllabs-scan:${CIRCLE_SHA1:0:7}
-      - docker push jumanjiman/ssllabs-scan:${CIRCLE_SHA1:0:7}
+      - docker tag jumanjiman/ssllabs-scan jumanjiman/ssllabs-scan:${VERSION}-${CIRCLE_SHA1:0:7}
+      - docker push jumanjiman/ssllabs-scan:${VERSION}-${CIRCLE_SHA1:0:7}
       - docker push jumanjiman/ssllabs-scan:latest
       - docker logout


### PR DESCRIPTION
* build with go-1.4.2
* build as an unprivileged user
* images now include upstream release version in docker tag