### PR TITLE
circleci: switch back to the default docker version

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,6 @@ machine:
     # If you change this, you should change it in Dockerfile.build, too.
     VERSION: 1.2.0
     TAG: ${VERSION}-$(date +%Y%m%dT%H%M)-git-${CIRCLE_SHA1:0:7}
-  pre:
-    - sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.0-circleci'
-    - sudo chmod 0755 /usr/bin/docker
   services:
     - docker
 


### PR DESCRIPTION
circleci now includes a more up-to-date version by default.