### PR TITLE
upgrade to ssllabs-scan v1.3.0

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,7 +1,7 @@
 FROM alpine:3.2
 
 # If you change this, you should change it in circle.yml, too.
-ENV version 1.2.0
+ENV version 1.3.0
 
 RUN apk upgrade --update --available && \
     apk add \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 static: clean
 	docker build -t scanbuild -f Dockerfile.build .
 	docker create --name scanbuild scanbuild true
-	docker cp scanbuild:/tmp/ssllabs-scan-1.2.0/ssllabs-scan .
+	docker cp scanbuild:/tmp/ssllabs-scan-1.3.0/ssllabs-scan .
 
 certfile: static
 	docker cp scanbuild:/etc/ssl/certs/ca-certificates.crt .

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 machine:
   environment:
     # If you change this, you should change it in Dockerfile.build, too.
-    VERSION: 1.2.0
+    VERSION: 1.3.0
     TAG: ${VERSION}-$(date +%Y%m%dT%H%M)-git-${CIRCLE_SHA1:0:7}
   services:
     - docker


### PR DESCRIPTION
https://github.com/ssllabs/ssllabs-scan/releases/tag/v1.3.0

> This release adds support for the API improvements in SSL Labs 1.21.13,
> released on 9 December 2015.
> This version exposes many improvements in the areas of HSTS and HPKP.