### PR TITLE
update ca-certificates

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,11 +1,11 @@
-FROM alpine:3.2
+FROM alpine:3.3
 
 # If you change this, you should change it in circle.yml, too.
 ENV version 1.3.0
 
 RUN apk upgrade --update --available && \
     apk add \
-      ca-certificates=20141019-r2 \
+      ca-certificates=20150426-r3 \
       go \
     && adduser -D developer \
     && rm -f /var/cache/apk/*


### PR DESCRIPTION
alpine 3.3 is out and has updated CA certs.
We copy the CA certs into the runtime image.