### PR TITLE
update ca-certificates

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -5,8 +5,9 @@ ENV version 1.3.0
 
 RUN apk upgrade --update --available && \
     apk add \
-      ca-certificates=20150426-r3 \
       go \
+    && apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
+      'ca-certificates>=20160104-r0' \
     && adduser -D developer \
     && rm -f /var/cache/apk/*
 


### PR DESCRIPTION
The certs get copied from the build image into the runtime,
so it's important to keep the certs up-to-date.