### PR TITLE
build with go 1.6 from alpine 3.4

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.4
 
 # If you change this, you should change it in circle.yml, too.
 ENV version 1.3.0
@@ -7,7 +7,8 @@ RUN apk upgrade --update --available && \
     apk add \
       go \
     && apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
-      'ca-certificates>=20160104-r2' \
+      'ca-certificates>=20160104-r4' \
+      openssl \
     && adduser -D developer \
     && rm -f /var/cache/apk/*
 


### PR DESCRIPTION
* upgrade builder base to alpine:3.4
* use go 1.6.x
* use latest ca-certificates
* add openssl to avoid `wget: can't execute 'ssl_helper'`
  because ca-certificates no longer adds openssl as a dependency as of
  http://git.alpinelinux.org/cgit/aports/commit/main/ca-certificates?h=3.4-stable&id=b464a7e6a14c6a16fddac39b0b9284d917539052