### PR TITLE
strip symbols from runtime binary

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -27,5 +27,5 @@ RUN cd /tmp && \
       -buildmode=exe \
       -installsuffix cgo \
       -tags netgo \
-      -ldflags '-w' \
+      -ldflags '-w -s' \
       ssllabs-scan.go


### PR DESCRIPTION
This reduces the built runtime image from 4.251 MiB to 3.895 MiB.

If somebody needs to add the symbol table back into the binary,
such as for debugging, the person can build locally or else
open a github issue to describe a reason to need the symbols.