### PR TITLE
abort build if VERSION env var is unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ clean:
 	docker rmi -f scanbuild || :
 
 static: clean
+ifndef VERSION
+	$(error VERSION environment variable is not set)
+endif
 	docker build \
 		--build-arg version=${VERSION} \
 		-t scanbuild -f Dockerfile.build .


### PR DESCRIPTION
Sometimes I build locally, and I forget to set VERSION.
Remind me.