### PR TITLE
builder: remove unnecessary dependency

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -10,7 +10,6 @@ RUN apk upgrade --update --available && \
       'go>=1.7.1-r0' \
     && apk add --no-cache -X http://dl-4.alpinelinux.org/alpine/edge/main \
       'ca-certificates>=20160104-r5' \
-      openssl \
     && adduser -D developer \
     && rm -f /var/cache/apk/*
 


### PR DESCRIPTION
Commit 77eb020a added openssl as a build-time dependency.
Alpine has since switched to libressl, and the libressl
dependencies are now present without the need to explicitly
declare libressl.