### PR TITLE
add label for CI build URL to refer back to circleci

### DIFF
--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,10 +1,12 @@
 FROM scratch
 
+ARG CI_BUILD_URL
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
 LABEL \
+    io.github.jumanjiman.ci-build-url=$CI_BUILD_URL \
     org.label-schema.name="jumanjiman/ssllabs-scan" \
     org.label-schema.description="scans secure websites with the Qualys SSL Labs service" \
     org.label-schema.url="https://github.com/jumanjihouse/docker-ssllabs-scan" \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ certfile: static
 
 runtime: static certfile
 	docker build \
+		--build-arg CI_BUILD_URL=${CIRCLE_BUILD_URL} \
 		--build-arg BUILD_DATE=${BUILD_DATE} \
 		--build-arg VCS_REF=${VCS_REF} \
 		--build-arg VERSION=${VERSION} \
@@ -42,6 +43,12 @@ test:
 
 	# Check that binary is stripped (no debug symbols).
 	file ssllabs-scan | grep -oh 'stripped'
+
+	# Check that image has ci-build-url label.
+	docker inspect \
+		-f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+		jumanjiman/ssllabs-scan | \
+		grep 'circleci.com'
 
 	# Check that binary works.
 ifdef CIRCLECI

--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ recent build.
     docker pull jumanjiman/ssllabs-scan:latest
 
 
+### View image labels
+
+Each built image has labels that generally follow http://label-schema.org/
+
+We add a label, `ci-build-url`, that is not currently part of the schema.
+This extra label provides a permanent link to the CI build for the image.
+
+View the ci-build-url label on a built image:
+
+    docker inspect \
+      -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+      jumanjiman/ssllabs-scan
+
+Query all the labels inside a built image:
+
+    docker inspect jumanjiman/ssllabs-scan | jq -M '.[].Config.Labels'
+
+
 ### Run
 
 The following example uses `--read-only` and `--cap-drop all` as recommended by the


### PR DESCRIPTION
This allows to inspect a built image and refer back to
a permanent link for the build on circleci.

It depends on env var `CIRCLE_BUILD_URL`, which gets set
on every build as described at
https://circleci.com/docs/environment-variables/