### PR TITLE
only check for ci-build-url label when testing on circleci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ test:
 	# Check that binary is stripped (no debug symbols).
 	file ssllabs-scan | grep -oh 'stripped'
 
+ifdef CIRCLECI
 	# Check that image has ci-build-url label.
 	docker inspect \
 		-f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
@@ -51,7 +52,6 @@ test:
 		grep 'circleci.com'
 
 	# Check that binary works.
-ifdef CIRCLECI
 	# Circle fails to drop all capabilities.
 	docker run -it --read-only jumanjiman/ssllabs-scan -grade -usecache https://github.com
 else


### PR DESCRIPTION
IOW, allow local build-and-test to succeed without the label.

Commit df44ac32c added the label and a test that the
label is present in the image, but the test breaks local testing.