### PR TITLE
ssllabs-scan: upgrade to v1.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 		--build-arg version=${VERSION} \
 		-t scanbuild -f Dockerfile.build .
 	docker create --name scanbuild scanbuild true
-	docker cp scanbuild:/tmp/ssllabs-scan-1.3.0/ssllabs-scan .
+	docker cp scanbuild:/tmp/ssllabs-scan-${VERSION}/ssllabs-scan .
 
 certfile: static
 	docker cp scanbuild:/etc/ssl/certs/ca-certificates.crt .

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/docs/docker
 machine:
   environment:
-    VERSION: 1.3.0
+    VERSION: 1.4.0
     BUILD_DATE: $(date +%Y%m%dT%H%M)
     VCS_REF: ${CIRCLE_SHA1:0:7}
     TAG: ${VERSION}-${BUILD_DATE}-git-${VCS_REF}


### PR DESCRIPTION
Upstream released v1.4.0 two days ago at
https://github.com/ssllabs/ssllabs-scan/releases/tag/v1.4.0

> This release adds support for the API improvement in SSL Labs 1.24.4,
> released 21st October 2016. This version adds support for Drown,
> CVE-2016-2107 and other improvements.

Thanks to @wan-tommy for alerting me to the need to upgrade.
Resolves https://github.com/jumanjihouse/docker-ssllabs-scan/issues/38