### PR TITLE
ci: use docker-compose to build and test

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 
-ARG version
+ARG VERSION
 
 RUN apk upgrade --update --available && \
     apk add --no-cache \
@@ -19,9 +19,9 @@ USER developer
 
 # https://github.com/golang/go/issues/9344#issuecomment-69944514
 RUN cd /tmp && \
-    curl -sSLO https://github.com/ssllabs/ssllabs-scan/archive/v${version}.tar.gz && \
-    tar xvzf v${version}.tar.gz && \
-    cd ssllabs-scan-${version} && \
+    curl -sSLO https://github.com/ssllabs/ssllabs-scan/archive/v${VERSION}.tar.gz && \
+    tar xvzf v${VERSION}.tar.gz && \
+    cd ssllabs-scan-${VERSION} && \
     GOPATH=~ \
     CGO_ENABLED=0 \
     GOOS=linux \

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,12 +1,12 @@
 FROM scratch
 
-ARG CI_BUILD_URL
+ARG CIRCLE_BUILD_URL
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
 
 LABEL \
-    io.github.jumanjiman.ci-build-url=$CI_BUILD_URL \
+    io.github.jumanjiman.ci-build-url=$CIRCLE_BUILD_URL \
     org.label-schema.name="jumanjiman/ssllabs-scan" \
     org.label-schema.description="scans secure websites with the Qualys SSL Labs service" \
     org.label-schema.url="https://github.com/jumanjihouse/docker-ssllabs-scan" \

--- a/Makefile
+++ b/Makefile
@@ -32,26 +32,8 @@ runtime: static certfile
 	docker images | grep ssllabs-scan
 
 test:
-	# Check that image exists.
-	docker images | grep ssllabs-scan
-
-	# Check that binary is static.
-	file ssllabs-scan | grep -oh 'statically linked'
-
-	# Check that binary is stripped (no debug symbols).
-	file ssllabs-scan | grep -oh 'stripped'
-	file ssllabs-scan | grep -vq 'not stripped'
-
-ifdef CIRCLECI
-	# Check that image has ci-build-url label.
-	docker inspect \
-		-f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
-		jumanjiman/ssllabs-scan | \
-		grep 'circleci.com'
-
-	# Check that binary works.
-	# Circle fails to drop all capabilities.
-	docker run -it --read-only jumanjiman/ssllabs-scan -grade -usecache https://github.com
-else
-	docker run -it --read-only --cap-drop all jumanjiman/ssllabs-scan -grade -usecache https://github.com
-endif
+	@echo
+	@echo 'WARNING: please run "ci/test" instead of "make test".'
+	@echo
+	@sleep 5
+	ci/test

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,12 @@
 # vim: set ts=8 sw=8 ai noet:
 
 .PHONY: all
-all: runtime
-
-clean:
-	rm -f ca-certificates.crt || :
-	rm -f ssllabs-scan || :
-	docker rm -f scanbuild || :
-	docker rmi -f scanbuild || :
-
-static: clean
-ifndef VERSION
-	$(error VERSION environment variable is not set)
-endif
-	docker build \
-		--build-arg version=${VERSION} \
-		-t scanbuild -f Dockerfile.build .
-	docker create --name scanbuild scanbuild true
-	docker cp scanbuild:/tmp/ssllabs-scan-${VERSION}/ssllabs-scan .
-
-certfile: static
-	docker cp scanbuild:/etc/ssl/certs/ca-certificates.crt .
-
-runtime: static certfile
-	docker build \
-		--build-arg CI_BUILD_URL=${CIRCLE_BUILD_URL} \
-		--build-arg BUILD_DATE=${BUILD_DATE} \
-		--build-arg VCS_REF=${VCS_REF} \
-		--build-arg VERSION=${VERSION} \
-		-t jumanjiman/ssllabs-scan -f Dockerfile.runtime .
-	docker images | grep ssllabs-scan
+all:
+	@echo
+	@echo 'WARNING: please run "ci/build" instead of "make all".'
+	@echo
+	@sleep 5
+	ci/build
 
 test:
 	@echo

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ How-to
 
 ### Build and test
 
-:warning: Build requires Docker 1.9.0 or later (for `docker build --build-arg`).
+:warning: Build requires Docker 1.9.0 or later as well as docker-compose.
 
     ci/build
     ci/test
@@ -138,3 +138,17 @@ file into the container:
     "https://www.google.com/": "B"
 
     2016/03/12 15:45:05 [INFO] All assessments complete; shutting down
+
+
+You can use `docker-compose` with the `docker-compose.yaml` file in this git repo:
+
+    $ docker-compose run --rm scanner -grade -usecache https://github.com
+    2017/05/13 15:35:37 [INFO] SSL Labs v1.28.5 (criteria version 2009o)
+    2017/05/13 15:35:37 [NOTICE] Server message: This assessment service is provided free of charge by Qualys SSL Labs, subject to our terms and conditions: https://www.ssllabs.com/about/terms.html
+    2017/05/13 15:35:39 [INFO] Assessment starting: https://github.com
+    2017/05/13 15:35:40 [INFO] Assessment complete: https://github.com (2 hosts in 108 seconds)
+        192.30.255.112: A+
+        192.30.255.113: A+
+    "https://github.com": "A+"
+
+    2017/05/13 15:35:40 [INFO] All assessments complete; shutting down

--- a/ci/build
+++ b/ci/build
@@ -19,7 +19,7 @@ ci/clean
 
 # Build the builder.
 docker build \
-  --build-arg version=${VERSION} \
+  --build-arg VERSION=${VERSION} \
   -t scanbuild -f Dockerfile.build .
 
 # Copy binary into local directory.

--- a/ci/build
+++ b/ci/build
@@ -18,24 +18,17 @@ EOF
 ci/clean
 
 # Build the builder.
-docker build \
-  --build-arg VERSION=${VERSION} \
-  -t scanbuild -f Dockerfile.build .
+docker-compose build builder
 
 # Copy binary into local directory.
-docker create --name scanbuild scanbuild true
+docker create --name scanbuild builder true
 docker cp scanbuild:/tmp/ssllabs-scan-${VERSION}/ssllabs-scan .
 
 # Copy certs into local directory.
 docker cp scanbuild:/etc/ssl/certs/ca-certificates.crt .
 
 # Build the runtime image.
-docker build \
-  --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL} \
-  --build-arg BUILD_DATE=${BUILD_DATE} \
-  --build-arg VCS_REF=${VCS_REF} \
-  --build-arg VERSION=${VERSION} \
-  -t jumanjiman/ssllabs-scan -f Dockerfile.runtime .
+docker-compose build scanner
 
 # Show image sizes.
 docker images | grep ssllabs-scan

--- a/ci/build
+++ b/ci/build
@@ -14,4 +14,28 @@ cat > ci/vars <<EOF
 EOF
 
 . ci/vars
-make all
+
+ci/clean
+
+# Build the builder.
+docker build \
+  --build-arg version=${VERSION} \
+  -t scanbuild -f Dockerfile.build .
+
+# Copy binary into local directory.
+docker create --name scanbuild scanbuild true
+docker cp scanbuild:/tmp/ssllabs-scan-${VERSION}/ssllabs-scan .
+
+# Copy certs into local directory.
+docker cp scanbuild:/etc/ssl/certs/ca-certificates.crt .
+
+# Build the runtime image.
+docker build \
+  --build-arg CI_BUILD_URL=${CIRCLE_BUILD_URL} \
+  --build-arg BUILD_DATE=${BUILD_DATE} \
+  --build-arg VCS_REF=${VCS_REF} \
+  --build-arg VERSION=${VERSION} \
+  -t jumanjiman/ssllabs-scan -f Dockerfile.runtime .
+
+# Show image sizes.
+docker images | grep ssllabs-scan

--- a/ci/build
+++ b/ci/build
@@ -31,7 +31,7 @@ docker cp scanbuild:/etc/ssl/certs/ca-certificates.crt .
 
 # Build the runtime image.
 docker build \
-  --build-arg CI_BUILD_URL=${CIRCLE_BUILD_URL} \
+  --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL} \
   --build-arg BUILD_DATE=${BUILD_DATE} \
   --build-arg VCS_REF=${VCS_REF} \
   --build-arg VERSION=${VERSION} \

--- a/ci/clean
+++ b/ci/clean
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Clean up from previous runs.
+rm -f ca-certificates.crt || :
+rm -f ssllabs-scan        || :
+docker rm -f scanbuild    || :
+docker rmi -f scanbuild   || :

--- a/ci/test
+++ b/ci/test
@@ -20,4 +20,7 @@ if [ -n "${CIRCLECI}" ]; then
 fi
 
 # Check that binary works.
-docker run -it --read-only --cap-drop all jumanjiman/ssllabs-scan -grade -usecache https://github.com
+docker-compose run --rm grade_github
+
+# Another syntax to do the same thing.
+docker-compose run --rm scanner -grade -usecache https://github.com

--- a/ci/test
+++ b/ci/test
@@ -1,4 +1,23 @@
 #!/bin/sh
 set -e
 
-make test
+# Check that image exists.
+docker images | grep ssllabs-scan
+
+# Check that binary is static.
+file ssllabs-scan | grep -oh 'statically linked'
+
+# Check that binary is stripped (no debug symbols).
+file ssllabs-scan | grep -oh 'stripped'
+file ssllabs-scan | grep -vq 'not stripped'
+
+if [ -n "${CIRCLECI}" ]; then
+  # Check that image has ci-build-url label.
+  docker inspect \
+    -f '{{ index .Config.Labels "io.github.jumanjiman.ci-build-url" }}' \
+    jumanjiman/ssllabs-scan | \
+    grep 'circleci.com'
+fi
+
+# Check that binary works.
+docker run -it --read-only --cap-drop all jumanjiman/ssllabs-scan -grade -usecache https://github.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: '2.1'
+
+services:
+  builder:
+    image: builder
+    env_file: ci/vars
+    build:
+      context: .
+      dockerfile: Dockerfile.build
+      args:
+        - VERSION
+
+  scanner: &defaults
+    image: jumanjiman/ssllabs-scan
+    env_file: ci/vars
+    build:
+      context: .
+      dockerfile: Dockerfile.runtime
+      args:
+        - CIRCLE_BUILD_URL
+        - BUILD_DATE
+        - VCS_REF
+        - VERSION
+    read_only: true
+    cap_drop:
+      - all
+    pids_limit: 10
+    cpu_shares: 512
+    mem_limit: 32M
+    shm_size: 16M
+    stdin_open: true
+    tty: true
+
+  grade_github:
+    <<: *defaults
+    command: -grade -usecache https://github.com


### PR DESCRIPTION
I'm not thrilled to add docker-compose as a dependency, but
it's nice to make the build slightly more declarative.
  
Plus, it simplifies the declaration of secure runtime options
when running the scanner.