### PR TITLE
change from x.y to x.y.z versions for Docker base images

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as scanner_builder
+FROM alpine:3.11.0 as scanner_builder
 
 ARG VERSION
 

--- a/sleeper/Dockerfile
+++ b/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11 as sleeper_builder
+FROM alpine:3.11.0 as sleeper_builder
 
 ARG VERSION
 


### PR DESCRIPTION
The expectation is to get more frequent updates from renovate-bot.
(update with each z version instead of just y versions)